### PR TITLE
Read h5

### DIFF
--- a/R/createAzimuthReference.R
+++ b/R/createAzimuthReference.R
@@ -12,7 +12,7 @@
 #' @param output_folder Where to save the Azimuth reference files for future calls
 #'  of `RunAzimuth`
 #' @param ndims Number of dimensions to use for PCA and UMAP
-#' @inheritDotParams Azimuth::AzimuthReference -refUMAP -refDR -object -refAssay
+#' @param \dots
 #'
 #' @returns A Seurat object with AzimuthData stored in the tools slot for use with Azimuth
 #' @export

--- a/R/readCounts10x.R
+++ b/R/readCounts10x.R
@@ -7,19 +7,30 @@
 #' @param min.cells Include features detected in at least this many cells. Will subset the counts matrix as well. To reintroduce excluded features, create a new object with a lower cutoff.
 #' @param min.features Include cells where at least this many features are detected.
 #' @param strip.suffix Whether to strip suffix from cellranger cell ID
+#' @param format Input format. "tsv" (default) uses `Seurat::Read10X` to load in for the barcodes.tsv, features.tsv and matrix.mtx in the directory specified by the `filepat`h param. "h5" loads the `*feature_bc_matrix.h5` file specifed by the `filepath` param.
 #'
 #' @return An object of class Seurat
 #'
 #' @importFrom Seurat Read10X CreateSeuratObject CreateAssayObject
+#'
+#' @note For `format = "tsv"` (default), `filepath` must specify the path to the *directory* containing `barcodes.tsv`, `features.tsv`, and `matrix.mtx`; whereas for `format = h5`, `filepath` must specify the path to the `*feature_bc_matrix.h5` *file*.
 #'
 #' @export
 readCounts10x <- function(capID,
                           filepath,
                           min.cells=0,
                           min.features=0,
-                          strip.suffix=FALSE) {
+                          strip.suffix=FALSE,
+                          format = "tsv") {
 
-  counts_in <- Seurat::Read10X(data.dir = filepath)
+  if (format == "tsv") {
+    counts_in <- Seurat::Read10X(data.dir = filepath)
+  } else if (format == "h5") {
+    counts_in <- Seurat::Read10X_h5(filepath, use.names = TRUE, unique.features = TRUE)
+  } else {
+    errorCondition("Must specify whether input format is 'tsv' or 'h5'")
+  }
+
   # Accommodate count matrices files with only RNA and those with multiple
   if ("Gene Expression" %in% names(counts_in)) {
     obj <- Seurat::CreateSeuratObject(counts_in$`Gene Expression`,

--- a/man/createAzimuthReference.Rd
+++ b/man/createAzimuthReference.Rd
@@ -16,26 +16,7 @@ of \code{RunAzimuth}}
 
 \item{ndims}{Number of dimensions to use for PCA and UMAP}
 
-\item{...}{
-  Arguments passed on to \code{\link[Azimuth:AzimuthReference]{Azimuth::AzimuthReference}}
-  \describe{
-    \item{\code{dims}}{Dimensions to use in reference neighbor finding}
-    \item{\code{k.param}}{Defines k for the k-nearest neighbor algorithm}
-    \item{\code{plotref}}{Either the name of the DimReduc in the provided Seurat object
-to use for the plotting reference or the DimReduc object itself.}
-    \item{\code{plot.metadata}}{A data.frame of discrete metadata fields for the cells
-in the plotref.}
-    \item{\code{ori.index}}{Index of the cells used in mapping in the original object on
-which UMAP was run. Only need to provide if UMAP was run on different set of
-cells.}
-    \item{\code{colormap}}{A list of named and ordered vectors specifying the colors and levels
-for the metadata. See \code{\link[Azimuth]{CreateColorMap}} for help
-generating your own.}
-    \item{\code{assays}}{Assays to retain for transfer}
-    \item{\code{metadata}}{Metadata to retain for transfer}
-    \item{\code{reference.version}}{Version of the Azimuth reference}
-    \item{\code{verbose}}{Display progress/messages}
-  }}
+\item{\dots}{}
 }
 \value{
 A Seurat object with AzimuthData stored in the tools slot for use with Azimuth

--- a/man/readCounts10x.Rd
+++ b/man/readCounts10x.Rd
@@ -9,7 +9,8 @@ readCounts10x(
   filepath,
   min.cells = 0,
   min.features = 0,
-  strip.suffix = FALSE
+  strip.suffix = FALSE,
+  format = "tsv"
 )
 }
 \arguments{
@@ -22,10 +23,15 @@ readCounts10x(
 \item{min.features}{Include cells where at least this many features are detected.}
 
 \item{strip.suffix}{Whether to strip suffix from cellranger cell ID}
+
+\item{format}{Input format. "tsv" (default) uses \code{Seurat::Read10X} to load in for the barcodes.tsv, features.tsv and matrix.mtx in the directory specified by the \code{filepat}h param. "h5" loads the \verb{*feature_bc_matrix.h5} file specifed by the \code{filepath} param.}
 }
 \value{
 An object of class Seurat
 }
 \description{
 Reads in 10X counts and metadata and returns Seurat obj
+}
+\note{
+For \code{format = "tsv"} (default), \code{filepath} must specify the path to the \emph{directory} containing \code{barcodes.tsv}, \code{features.tsv}, and \code{matrix.mtx}; whereas for \code{format = h5}, \code{filepath} must specify the path to the \verb{*feature_bc_matrix.h5} \emph{file}.
 }


### PR DESCRIPTION
- Added ability of readCounts10x() to handle h5 using Seurat::Read10x_h5()
- Also fixed the Azimuth error similarly to PR #46 

This should be completely backwards compatible, as the default is still to use Seurat::Read10x()