### PR TITLE
Making plotting proportions the default for `plotClusterAnnotTile()`

### DIFF
--- a/man/plotClusterAnnotTile.Rd
+++ b/man/plotClusterAnnotTile.Rd
@@ -4,7 +4,12 @@
 \alias{plotClusterAnnotTile}
 \title{Plot comparing unsupervised clusters to cell annotations}
 \usage{
-plotClusterAnnotTile(obj.seurat, labels, assay = "RNA", plot_portions = FALSE)
+plotClusterAnnotTile(
+  obj.seurat,
+  labels,
+  assay = "RNA",
+  plot_proportions = TRUE
+)
 }
 \arguments{
 \item{obj.seurat}{Seurat object}
@@ -13,7 +18,7 @@ plotClusterAnnotTile(obj.seurat, labels, assay = "RNA", plot_portions = FALSE)
 
 \item{assay}{Assay to use (default "RNA")}
 
-\item{plot_portions}{Whether to plot portions instead of raw counts, default FALSE}
+\item{plot_proportions}{Whether to plot proportions instead of raw counts, default TRUE}
 }
 \value{
 ggplot object UMAP

--- a/man/plotIntegrationDiagnostics.Rd
+++ b/man/plotIntegrationDiagnostics.Rd
@@ -12,6 +12,7 @@ plotIntegrationDiagnostics(
   sample_col,
   cell_labels,
   res,
+  plot_proportions = TRUE,
   ...
 )
 }
@@ -30,8 +31,9 @@ plotIntegrationDiagnostics(
 
 \item{res}{Resolution(s) to use for \code{\link[Seurat:FindClusters]{FindClusters()}}. May be scalar or vector of multiple resolutions to loop over.}
 
-\item{\dots}{Additional arguments passed to \code{Seurat::DimPlot()}, useful for controlling rasterization or
-point size for large datasets}
+\item{plot_proportions}{Whether to plot the proprotion of cells assigned to each cell type in a given cluster for \code{plotClusterAnnotTile()}}
+
+\item{\dots}{Additional arguments passed to \code{Seurat::DimPlot()}, useful for controlling rasterization or point size for large datasets}
 }
 \value{
 A list of ggplot objects in a structure like so:


### PR DESCRIPTION
Making plotting proportions the default for `plotClusterAnnotTile()`, plus fixing some typos and updating documentation for that function